### PR TITLE
Feat/presentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/dragonfly-48.png" />
+    <link rel="icon" type="image/svg+xml" href="/src/assets/dragonfly-48.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>PORTFOLIO</title>
   </head>

--- a/src/components/Education.tsx
+++ b/src/components/Education.tsx
@@ -212,7 +212,7 @@ const Education = () => {
           viewport={{ once: true }}
           className="text-center mb-16"
         >
-          <h2 className="text-4xl md:text-5xl font-bold gradient-text mb-6 drop-shadow-sm theme-vintage:text-vintage-mustard-light theme-vintage:drop-shadow-lg">
+          <h2 className="text-4xl md:text-5xl mb-8 brutal-title">
             {educationTranslations.title}
           </h2>
           <p className="text-xl text-gray-700 dark:text-gray-300 max-w-2xl mx-auto font-medium leading-relaxed theme-vintage:text-vintage-cream theme-vintage:font-semibold theme-vintage:text-shadow theme-retro-pastel:text-retroPastel-text/90">

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -479,13 +479,7 @@ const Experience = () => {
           className="text-center mb-16"
         >
           {" "}
-          <h2
-            className={`text-4xl md:text-5xl font-bold mb-6 ${
-              theme === "brutalism"
-                ? "text-black [text-shadow:4px_4px_0_#00000020]"
-                : "gradient-text"
-            }`}
-          >
+          <h2 className="text-4xl md:text-5xl mb-8 brutal-title">
             {t("experience.title")}
           </h2>
           <p className="text-xl text-gray-400 max-w-2xl mx-auto">

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -222,15 +222,17 @@ const Hero = () => {
                   : "bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600"
               }`}
               style={{
-                lineHeight: "1.2",
-                textShadow:
-                  theme === "dark"
-                    ? "0 0 20px rgba(59, 130, 246, 0.3)"
-                    : theme === "brutalism"
-                    ? "2px 2px 0 #000, -1px -1px 0 #fff, 1px -1px 0 #000, -1px 1px 0 #fff, 1px 1px 0 #000"
-                    : "0 2px 8px rgba(147, 51, 234, 0.2)",
-                WebkitTextStroke: theme === "brutalism" ? "0.5px #000" : "none",
-                letterSpacing: theme === "brutalism" ? "-1px" : "normal",
+                fontSize: '4.5rem',
+                lineHeight: '1.1',
+                color: '#ef7574',
+                textShadow: 
+                  '2px 2px 0 #000, ' + 
+                  '-1px -1px 0 #f8d7da, ' +
+                  '-1px -2px 0 #f5b5b5, ' +
+                  '1px -1px 0 #000, ' +
+                  '-1px 1px 0 #000, ' +
+                  '1px 1px 0 #000',
+                WebkitTextStroke: '0.5px #000'
               }}
               initial={{ scale: 0.8, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -210,9 +210,15 @@ const Hero = () => {
             transition={{ duration: 0.8, delay: 0.3 }}
           >
             <motion.h1
-              className={`text-4xl md:text-5xl lg:text-6xl font-bold mb-4 bg-clip-text text-transparent ${
+              className={`text-4xl md:text-5xl lg:text-6xl font-bold mb-4 ${
+                theme === "brutalism"
+                  ? "text-black"
+                  : "bg-clip-text text-transparent"
+              } ${
                 theme === "dark"
                   ? "bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-600"
+                  : theme === "brutalism"
+                  ? ""
                   : "bg-gradient-to-r from-blue-600 via-purple-600 to-pink-600"
               }`}
               style={{
@@ -220,7 +226,11 @@ const Hero = () => {
                 textShadow:
                   theme === "dark"
                     ? "0 0 20px rgba(59, 130, 246, 0.3)"
+                    : theme === "brutalism"
+                    ? "2px 2px 0 #000, -1px -1px 0 #fff, 1px -1px 0 #000, -1px 1px 0 #fff, 1px 1px 0 #000"
                     : "0 2px 8px rgba(147, 51, 234, 0.2)",
+                WebkitTextStroke: theme === "brutalism" ? "0.5px #000" : "none",
+                letterSpacing: theme === "brutalism" ? "-1px" : "normal",
               }}
               initial={{ scale: 0.8, opacity: 0 }}
               animate={{ scale: 1, opacity: 1 }}
@@ -231,13 +241,20 @@ const Hero = () => {
 
             <motion.h2
               className={`text-xl md:text-2xl lg:text-3xl font-medium mb-6 ${
-                theme === "dark" ? "text-slate-200" : "text-gray-700"
+                theme === "dark"
+                  ? "text-slate-200"
+                  : theme === "brutalism"
+                  ? "text-black font-bold"
+                  : "text-gray-700"
               }`}
               style={{
                 textShadow:
                   theme === "dark"
                     ? "0 2px 8px rgba(0,0,0,0.4)"
+                    : theme === "brutalism"
+                    ? "1px 1px 0 #000, -0.5px -0.5px 0 #fff, 0.5px -0.5px 0 #000, -0.5px 0.5px 0 #fff, 0.5px 0.5px 0 #000"
                     : "0 1px 4px rgba(0,0,0,0.1)",
+                WebkitTextStroke: theme === "brutalism" ? "0.3px #000" : "none",
               }}
               initial={{ y: 20, opacity: 0 }}
               animate={{ y: 0, opacity: 1 }}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -301,7 +301,7 @@ const Projects = () => {
           viewport={{ once: true }}
           className="text-center mb-16"
         >
-          <h2 className="text-4xl md:text-5xl font-bold gradient-text mb-6">
+          <h2 className="text-4xl md:text-5xl mb-8 brutal-title">
             {projectsTranslationsHook.title}
           </h2>
           <p className="text-xl text-gray-400 max-w-2xl mx-auto">

--- a/src/components/Skill3DCard.tsx
+++ b/src/components/Skill3DCard.tsx
@@ -78,42 +78,77 @@ const Skill3DCard = ({
     <div ref={cardRef} className="relative cursor-pointer perspective-1000">
       {" "}
       <animated.div
-        className={`p-4 rounded-xl transform-style-3d ${
-          theme === "dark" ? "bg-slate-800/80" : "bg-white/90"
-        } backdrop-blur-sm`}
+        className={`p-4 transform-style-3d ${
+          theme === "dark"
+            ? "bg-slate-800/80"
+            : theme === "brutalism"
+            ? "bg-[#fff4d3] border-2 border-black"
+            : "bg-white/90"
+        } ${
+          theme === "brutalism" ? "rounded-none" : "rounded-xl backdrop-blur-sm"
+        }`}
         style={{
           rotateX: springProps.rotateX,
           rotateY: springProps.rotateY,
           scale: springProps.scale,
           translateZ: springProps.zIndex,
-          boxShadow: isHovered
-            ? `0 10px 25px -5px ${config.glowColor}, 0 8px 10px -6px ${config.glowColor}`
-            : theme === "dark"
-            ? "0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -4px rgba(0, 0, 0, 0.2)"
-            : "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)",
+          boxShadow:
+            theme === "brutalism"
+              ? isHovered
+                ? "4px 4px 0 #000, 0 0 0 1px #000"
+                : "3px 3px 0 #000, 0 0 0 1px #000"
+              : isHovered
+              ? `0 10px 25px -5px ${config.glowColor}, 0 8px 10px -6px ${config.glowColor}`
+              : theme === "dark"
+              ? "0 10px 15px -3px rgba(0, 0, 0, 0.3), 0 4px 6px -4px rgba(0, 0, 0, 0.2)"
+              : "0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1)",
+          transform: theme === "brutalism" ? "translateZ(10px)" : "none",
+          transition: theme === "brutalism" ? "all 0.2s ease" : "none",
         }}
       >
         {/* Card content */}
         <div className="flex flex-col items-center p-2">
           {/* Icon */}
           <div
-            className={`w-16 h-16 flex items-center justify-center rounded-full bg-gradient-to-br ${color} mb-3`}
+            className={`w-16 h-16 flex items-center justify-center ${
+              theme === "brutalism" ? "border border-black" : "rounded-full"
+            } bg-gradient-to-br ${color} mb-3`}
           >
-            <Icon className="w-8 h-8 text-white" />
+            <Icon
+              className={`w-8 h-8 ${
+                theme === "brutalism" ? "text-black" : "text-white"
+              }`}
+            />
           </div>
 
           {/* Skill name */}
           <h3
-            className={`text-lg font-semibold mb-1 ${
-              theme === "dark" ? "text-white" : "text-gray-800"
+            className={`text-lg font-bold mb-1 ${
+              theme === "dark"
+                ? "text-white"
+                : theme === "brutalism"
+                ? "text-black"
+                : "text-gray-800"
             }`}
+            style={{
+              WebkitTextStroke: theme === "brutalism" ? "0.3px #000" : "none",
+              textShadow: theme === "brutalism" ? "0.5px 0.5px 0 #000" : "none",
+            }}
           >
             {name}
           </h3>
 
           {/* Level indicator */}
           {level && (
-            <div className="w-full bg-gray-200 dark:bg-gray-700/50 rounded-full h-1.5">
+            <div
+              className={`w-full ${
+                theme === "dark"
+                  ? "bg-gray-700/50"
+                  : theme === "brutalism"
+? "bg-gray-300 border-t border-b border-l-2 border-r-2 border-black"
+                  : "bg-gray-200"
+              } ${theme === "brutalism" ? "h-2" : "h-1.5 rounded-full"}`}
+            >
               <div className={getLevelStyles()}></div>
             </div>
           )}

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -251,7 +251,7 @@ const Skills = () => {
           viewport={{ once: true }}
           className="text-center mb-16"
         >
-          <h2 className="text-4xl md:text-5xl font-bold gradient-text mb-6">
+          <h2 className="text-4xl md:text-5xl mb-8 brutal-title">
             {skillsTranslations.title}
           </h2>
           <p className="text-xl text-gray-800 dark:text-gray-200 max-w-2xl mx-auto font-medium leading-relaxed">

--- a/src/index.css
+++ b/src/index.css
@@ -1016,6 +1016,44 @@
 }
 
 @layer utilities {
+  /* Estilo brutalista mejorado para títulos */
+  .brutal-title {
+    @apply font-bold;
+    color: #ef7574; /* Color rojo suave */
+    text-shadow: 
+      /* Sombra negra abajo */
+      2px 2px 0 #000,
+      /* Sombra clara arriba */
+      -1px -1px 0 #f8d7da,
+      -1px -2px 0 #f5b5b5,
+      /* Contorno */
+      1px -1px 0 #000,
+      -1px 1px 0 #000,
+      1px 1px 0 #000;
+    -webkit-text-stroke: 0.5px #000;
+    letter-spacing: -0.5px;
+    position: relative;
+    display: inline-block;
+  }
+
+  .brutal-title::after {
+    content: '';
+    position: absolute;
+    bottom: -8px;
+    left: 0;
+    width: 100%;
+    height: 4px;
+    background: linear-gradient(90deg, #f56565, #1a365d);
+    transform: scaleX(0.8);
+    transform-origin: center;
+    transition: transform 0.3s ease, background 0.3s ease;
+  }
+
+  .brutal-title:hover::after {
+    transform: scaleX(1);
+    background: linear-gradient(90deg, #f56565, #1a365d);
+  }
+
   .text-shadow {
     text-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   }


### PR DESCRIPTION
This pull request introduces a series of changes to implement a "brutalist" design theme across various components and styles in the project. The updates include styling adjustments for headings, cards, and other elements to align with the brutalist aesthetic. Additionally, there is a minor fix to the favicon path in the `index.html` file.

### Theme-related changes:
* **Introduced a new brutalist title style**: Added a `brutal-title` class in `src/index.css` with bold typography, unique text shadows, and hover effects. This class is applied to headings across components like `Education`, `Experience`, `Projects`, and `Skills` for a consistent brutalist look. [[1]](diffhunk://#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09eR1019-R1056) [[2]](diffhunk://#diff-e920001e2e9250184bc8f0619862c98ee8de73d1689941a568f8016b91bccedeL215-R215) [[3]](diffhunk://#diff-20639f706e5027e9b725ea6c4732baea79e7fd505f476e2aa8a9cc23fe58e8dfL482-R482) [[4]](diffhunk://#diff-95c2ab777917d7c35d44ac715c43a8376b3f137c95671f49dea1173a37c3eef9L304-R304) [[5]](diffhunk://#diff-7a8ac3e1f42f09907f65e746535d42e3e24ac1ddb8dbf147a27a9e5f541f376bL254-R254)
* **Updated `Hero` component styling**: Adjusted the main and secondary headings to support brutalist-specific styles, including text shadows, font sizes, and WebKit text strokes. [[1]](diffhunk://#diff-1cadf8397b7345b9f320a7c7e007a8bc697f2c9deec3085de9bd17e057ac0f0aL213-R235) [[2]](diffhunk://#diff-1cadf8397b7345b9f320a7c7e007a8bc697f2c9deec3085de9bd17e057ac0f0aL234-R259)
* **Enhanced `Skill3DCard` component**: Modified the card design to include brutalist-specific styles such as sharp edges, bold borders, and unique box shadows.

### General fixes:
* **Updated favicon path**: Fixed the favicon reference in `index.html` to point to the correct location (`/src/assets/dragonfly-48.png`).